### PR TITLE
[libxcrypt] Add %license files. JB#55991

### DIFF
--- a/rpm/libxcrypt.spec
+++ b/rpm/libxcrypt.spec
@@ -385,6 +385,7 @@ done
 
 
 %files
+%license AUTHORS COPYING.LIB LICENSING
 %doc %dir %{_docdir}/%{name}
 %doc %{_docdir}/%{name}/NEWS
 %doc %{_docdir}/%{name}/README


### PR DESCRIPTION
@Thaodan @Tomin1 @mlehtima 

As side note the .spec could use some cleaning up. Quite complicated and feels like it's having still a lot of Fedora legacy which isn't getting used here at all. Doesn't build in platform sdk either.